### PR TITLE
Send email with notify

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -1,11 +1,9 @@
 // Load environment variables from .env file
 require('dotenv').config();
-console.log("NOTIFYAPIKEY:", process.env.NOTIFYAPIKEY);
 const NotifyClient = require('notifications-node-client').NotifyClient;
 
-const express = require('express');
-const router = express.Router();  // Declare the router variable only once
-
+const govukPrototypeKit = require('govuk-prototype-kit')
+const router = govukPrototypeKit.requests.setupRouter()
 
 // Handle POST request from the claimant-name form
 router.post('/claimant-name', function(req, res) {
@@ -70,6 +68,16 @@ router.post('/child-facing', (req, res) => {
     // Redirect to the randomly chosen page
     return res.redirect(nextPage);
 });
+
+router.post('/email-address-page', (req, res) => {
+	const notify = new NotifyClient(process.env.NOTIFYAPIKEY);
+	notify.sendEmail(
+		'e571db62-1c28-4d43-990b-ad856dd47bbf',
+		req.body.emailAddress
+	)
+
+	res.redirect('/confirmation-page');
+})
 
 // Define route for child-facing-A
 router.get('/child-facing-A', (req, res) => {

--- a/app/views/email-address-page.html
+++ b/app/views/email-address-page.html
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <form class="form" id="email-form" method="post"> 
+    <form class="form" id="email-form" method="post" action="/email-address-page">
       {{ govukInput({
         label: {
           text: "Email Address"
@@ -25,18 +25,3 @@
 </div>
 
 {% endblock %}
-
-<script>
-
-const sendEmail = require('./test'); // Import the sendEmail function
-
-  document.getElementById('emailForm').addEventListener('submit', function(event) {
-      event.preventDefault(); // Prevent default form submission
-      
-      const email = document.getElementById('email').value; // Get user input email
-      
-      // Call sendEmail function with the user input email
-      sendEmail(email);
-  });
-
-  </script>


### PR DESCRIPTION
Previously the router was not being used by the prototype kit so **some of the journey may change** as pages are now hitting the router.

Updates the `email-address-page` to post to the `/email-address-route` and send an email via notify.

I wasn't sure where the email page should redirect to so just change this line
`res.redirect('/confirmation-page');`
to point at the appropriate post email page.

Also of note I couldn't quite test the email sending as the api key is for team accounts but the error back from notify indicates this should work when sending emails to a "team" address

```
    data: {
      errors: [
        {
          error: 'BadRequestError',
          message: 'Can’t send to this recipient using a team-only API key'
        }
      ],
      status_code: 400
    }
```