### PR TITLE
Sc jira 883

### DIFF
--- a/app/views/child-facing-A.html
+++ b/app/views/child-facing-A.html
@@ -32,11 +32,11 @@
         <fieldset class="govuk-fieldset" aria-describedby="declaration-A-error">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              Confirm {{ data['firstName'] }} spends most of their time in their job working directly with children
+              Confirm {{ data['firstName'] }} spends most of their time in their role working directly with children
             </h1>
           </legend>
           <div id="declaration-A-hint" class="govuk-hint">
-            {{ data['firstName'] }}’s job must involve spending most of their contracted hours (approximately 70% or more) working directly with children.
+            {{ data['firstName'] }}’s role must involve spending most of their contracted hours (approximately 70% or more) working directly with children.
           </div>
           <p id="declaration-A-error" class="govuk-error-message" style="display: none;">
             <span class="govuk-visually-hidden">Error:</span> You must be able to confirm this information to continue
@@ -45,7 +45,7 @@
             <div class="govuk-checkboxes__item">
               <input class="govuk-checkboxes__input" id="declaration-A" name="declarationA" type="checkbox" value="checked">
               <label class="govuk-label govuk-checkboxes__label" for="declaration-A">
-                I confirm that at least 70% of {{ data['firstName'] }}’s time in their job is spent working directly with children.
+                I confirm that at least 70% of {{ data['firstName'] }}’s time in their role is spent working directly with children.
               </label>
             </div>
           </div>

--- a/app/views/child-facing-B.html
+++ b/app/views/child-facing-B.html
@@ -34,11 +34,11 @@
         <fieldset class="govuk-fieldset" aria-describedby="declaration-B-error">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              Does {{ data['firstName'] }} spend most of the time in their job working directly with children? 
+              Does {{ data['firstName'] }} spend most of the time in their role working directly with children? 
             </h1>
           </legend>
   <div id="child-facing-B-hint" class="govuk-hint">
-    {{ data ['firstName'] }}’s job must involve spending most of their contracted hours (approximately 70% or more) directly working with children.
+    {{ data ['firstName'] }}’s role must involve spending most of their contracted hours (approximately 70% or more) directly working with children.
   </div>
   <p id="declaration-B-error" class="govuk-error-message" style="display: none;">
     <span class="govuk-visually-hidden">Error:</span> You must select an option below to continue

--- a/app/views/consent.html
+++ b/app/views/consent.html
@@ -38,7 +38,7 @@
               </h1>
             </legend>
 			<p>
-              You need to confirm that you’ve got consent from your employee before you can continue with a claim.</p>
+              You need to confirm that you’ve got consent from your employee before you can continue with your claim.</p>
             <p>
 
       <p>

--- a/app/views/landing-page.html
+++ b/app/views/landing-page.html
@@ -64,10 +64,10 @@
 
       <ul class="govuk-list govuk-list--bullet">
 		
-        <li>have applied for a job with an incentive attached</li>
-        <li>have started their job after 15 May 2024</li>
-		<li>not have had a permanent job working directly with children in an early years setting in the 6 months before starting their current job</li>
-        <li>spend most of the time in their job (70% or more) working directly with children</li>
+        <li>have applied for a permanent part or full-time role with an incentive attached</li>
+        <li>have started the role after 15 May 2024</li>
+		<li>not have had a permanent role working directly with children in an early years setting in the 6 months before starting their current role</li>
+        <li>spend most of the time in their role (70% or more) working directly with children</li>
       </ul>
 	  
 	          <p>Working directly with children can involve any of the following:</p>
@@ -81,9 +81,9 @@
 		
 		
 		<h3 class="govuk-heading-m">
-		Employees who have worked in the 6 months before starting their current job</h3>
+		Employees who have worked in the 6 months before starting their current role</h3>
 		
-		<p>If your employee has worked in an early years setting in the 6 months before starting their current job, you can claim if their work was:
+		<p>If your employee has worked in an early years setting in the 6 months before starting their current role, you can claim if their work was:
 <ul class="govuk-list govuk-list--bullet">
         <li>voluntary or unpaid</li>
         <li>casual and temporary</li>
@@ -95,13 +95,12 @@
           <li>guaranteed minimum hour contracts</li>
           <li>self-employed or freelance contracts</li>
           <li>fixed term contracts (FTCs)</li>
-          <li>agency work and apprenticeship jobs</li>
+          <li>agency work and apprenticeship roles</li>
         </ul>
 		
-		<p>You cannot make a claim if they had a permanent job working directly with children in an early years setting.</p>
+		<p>You cannot make a claim if they had a permanent role working directly with children in an early years setting.</p>
    
-       <p>You can find more information about employment contracts on the <a href>ACAS website</a>.</p>
-        
+           
         <p>More information can be found in the <a href>guidance</a>.</p>
 
 
@@ -195,7 +194,7 @@
       <h2 class="govuk-heading-l">
         Cancel or get help with your claim
       </h2>
-      <p>If your employee leaves their job before they’ve been in it for 6 months, you should cancel their claim</a>. </p>
+      <p>If your employee leaves their role before they’ve been in it for 6 months, you need to cancel their claim</a>. </p>
       <p>You can cancel a claim or get help on this service by contacting us at <a href="">help@opsteam.education.gov.uk</a>. </p>
       <p>Read more about the <a href="">early years financial incentive payment</a>.</p>
       

--- a/app/views/paye-reference.html
+++ b/app/views/paye-reference.html
@@ -36,8 +36,8 @@
       </label>
     </h1>
     <div id="employee-paye-hint" class="govuk-hint">
-      This is a series of numbers and letters separated with a slash, like 123/AB456.
-Your organisation's payroll or human resources can provide this.
+      This is a series of numbers and letters separated with a slash, like 123/AB456. Your organisation's payroll or human resources can provide this.
+We need this to check that the employee is still working at your setting after 6 months.
     </div>
 
       <form class="form" action="/claimant-name" method="post" onsubmit="return validateForm();">

--- a/app/views/returner-2.html
+++ b/app/views/returner-2.html
@@ -34,7 +34,7 @@
         <fieldset class="govuk-fieldset" aria-describedby="returner-two-error">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-             Did {{ data['firstName'] }}'s previous job in an early years setting involve mostly working directly with children?
+             Did {{ data['firstName'] }}'s previous role in an early years setting involve mostly working directly with children?
             </h1>
           </legend>
   <br>
@@ -65,7 +65,7 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <p class="govuk-body">Your employee spends most of the time in their job (70% or more) working directly with children.</p>
+    <p class="govuk-body">Your employee spends most of the time in their role (70% or more) working directly with children.</p>
   </div>
   <div class="govuk-details__text">
     <p class="govuk-body">Working directly with children can involve:</p>

--- a/app/views/returner-4A.html
+++ b/app/views/returner-4A.html
@@ -34,7 +34,7 @@
         <fieldset class="govuk-fieldset" aria-describedby="returner-three-error">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              Was {{ data['firstName'] }}'s previous job in an early years setting non-permanent?
+              Was {{ data['firstName'] }}'s previous role in an early years setting non-permanent?
             </h1>
           </legend>
   <p id="returner-three-error" class="govuk-error-message" style="display: none;">
@@ -63,8 +63,8 @@
       </span>
     </summary>
     <div class="govuk-details__text">
-      <p class="govuk-body">In the six months before starting their current job, your employee must not have had a permanent job working directly with children in an early years setting.</p>
-      <p>If they did work in early years in the 6 months before starting their current job, you can claim if this was in the following types of employment:</p>
+      <p class="govuk-body">In the six months before starting their current role, your employee must not have had a permanent role working directly with children in an early years setting.</p>
+      <p>If they did work in early years in the 6 months before starting their current role, you can claim if this was in the following types of employment:</p>
   
       <ul class="govuk-list govuk-list--bullet">
         <li>voluntary or unpaid work</li>
@@ -76,9 +76,9 @@
           <li>guaranteed minimum hour contracts</li>
           <li>self-employed or freelance contracts</li>
           <li>fixed term contracts (FTCs)</li>
-          <li>agency work and apprenticeship jobs</li>
+          <li>agency work and apprenticeship roles</li>
           </ul>
-          <p>You can find more information about employment contracts on the <a href="">ACAS website.</a></p>
+          
     </div>
   </details>
   

--- a/app/views/returner-4B.html
+++ b/app/views/returner-4B.html
@@ -34,7 +34,7 @@
         <fieldset class="govuk-fieldset" aria-describedby="returner-three-error">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              Select the contract type for {{ data['firstName'] }}'s previous job in an early years setting
+              Select the contract type for {{ data['firstName'] }}'s previous role in an early years setting
             </h1>
           </legend>
   <p id="returner-four-error" class="govuk-error-message" style="display: none;">
@@ -63,7 +63,7 @@
     <div class="govuk-radios__item">
       <input class="govuk-radios__input" id="returner-four-no" name="returnerFour" type="radio" value="agency work and apprenticeship jobs">
       <label class="govuk-label govuk-radios__label" for="returner-four-no">
-        agency work and apprenticeship jobs
+        agency work and apprenticeship roles
       </label>
     </div>
     </div>
@@ -81,10 +81,9 @@
           <li>guaranteed minimum hour contracts</li>
           <li>self-employed or freelance contracts</li>
           <li>fixed term contracts (FTCs)</li>
-          <li>agency work and apprenticeship jobs</li>
+          <li>agency work and apprenticeship roles</li>
           </ul>
-          <p>You can find more information about employment contracts on the <a href="">ACAS website.</a></p>
-    </div>
+              </div>
   </details>
   
 


### PR DESCRIPTION
The term 'job' changed to 'role' across multiple page.
permanent job clarification on landing-page eligibility
Reason for paye reference need added to hint text in paye-reference 